### PR TITLE
Add [CEReactions] annotation to capture

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
       </p>
       <dl title="partial interface HTMLInputElement" class="idl">
         <dt>
-          attribute boolean capture
+          [CEReactions] attribute boolean capture
         </dt>
         <dd></dd>
       </dl>


### PR DESCRIPTION
Since the capture attribute can change the DOM in ways that may impact custom elements, it needs to be annotated with the [CEReactions] attribute. This is part of the larger effort at w3c/webcomponents#186. [CEReactions] is defined in https://html.spec.whatwg.org/multipage/scripting.html#cereactions.
