### PR TITLE
Fix broken fragments

### DIFF
--- a/releases/CR3.html
+++ b/releases/CR3.html
@@ -352,7 +352,7 @@
     <p><em>This section is non-normative.</em></p>
     <p data-link-for="HTMLInputElement">
       The <cite>HTML Media Capture</cite> specification extends the
-      <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#htmlinputelement"><code>HTMLInputElement</code></a> interface with a <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute. The
+      <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#htmlinputelement-htmlinputelement"><code>HTMLInputElement</code></a> interface with a <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute. The
       <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute allows authors to declaratively request use of a <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media capture mechanism</a>, such as a camera or microphone, from within a file upload control, for capturing media on the spot.
     </p>
     <p>
@@ -385,13 +385,13 @@
       </span>
     </h2>
     <p>
-      The <dfn data-dfn-type="dfn" id="dfn-input"><a href="https://www.w3.org/TR/html51/single-page.html#the-input-element"><code>input</code></a></dfn> element, its <dfn data-dfn-type="dfn" id="dfn-type"><a href="https://www.w3.org/TR/html51/single-page.html#attr-input-type"><code>type</code></a></dfn> attribute,
-      <dfn data-dfn-for="" data-dfn-type="dfn" id="dom-htmlinputelement" data-idl="" data-title="HTMLInputElement"><a href="https://www.w3.org/TR/html51/single-page.html#htmlinputelement"><code>HTMLInputElement</code></a></dfn> interface,
-      <dfn data-dfn-type="dfn" id="dfn-accept"><a href="https://www.w3.org/TR/html51/single-page.html#attr-input-accept"><code>accept</code></a></dfn> attribute, <dfn data-dfn-type="dfn" id="dfn-file-upload"><a href="https://www.w3.org/TR/html51/single-page.html#file-upload-state-(type=file)">File
-        Upload</a></dfn> state, <dfn data-dfn-type="dfn" id="dfn-enumerated-attribute"><a href="https://www.w3.org/TR/html51/single-page.html#enumerated-attribute">enumerated attribute</a></dfn>,
+      The <dfn data-dfn-type="dfn" id="dfn-input"><a href="https://www.w3.org/TR/html51/single-page.html#the-input-element"><code>input</code></a></dfn> element, its <dfn data-dfn-type="dfn" id="dfn-type"><a href="https://www.w3.org/TR/html51/single-page.html#element-attrdef-input-type"><code>type</code></a></dfn> attribute,
+      <dfn data-dfn-for="" data-dfn-type="dfn" id="dom-htmlinputelement" data-idl="" data-title="HTMLInputElement"><a href="https://www.w3.org/TR/html51/single-page.html#htmlinputelement-htmlinputelement"><code>HTMLInputElement</code></a></dfn> interface,
+      <dfn data-dfn-type="dfn" id="dfn-accept"><a href="https://www.w3.org/TR/html51/single-page.html#element-attrdef-input-accept"><code>accept</code></a></dfn> attribute, <dfn data-dfn-type="dfn" id="dfn-file-upload"><a href="https://www.w3.org/TR/html51/single-page.html#file-upload-state-typefile">File
+        Upload</a></dfn> state, <dfn data-dfn-type="dfn" id="dfn-enumerated-attribute"><a href="https://www.w3.org/TR/html51/single-page.html#enumerated-attributes">enumerated attribute</a></dfn>,
       <dfn data-dfn-type="dfn" id="dfn-missing-value-default"><a href="https://www.w3.org/TR/html51/single-page.html#missing-value-default">missing value
         default</a></dfn>, <dfn data-dfn-type="dfn" id="dfn-invalid-value-default"><a href="https://www.w3.org/TR/html51/single-page.html#invalid-value-default">invalid
-        value default</a></dfn>, and <dfn data-dfn-type="dfn" id="dfn-reflect"><a href="https://www.w3.org/TR/html51/single-page.html#reflect">reflect</a></dfn> are defined in [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>].
+        value default</a></dfn>, and <dfn data-dfn-type="dfn" id="dfn-reflect"><a href="https://www.w3.org/TR/html51/single-page.html#reflection">reflect</a></dfn> are defined in [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>].
     </p>
     <p>
       The <dfn data-dfn-type="dfn" id="dfn-videofacingmodeenum"><a href="https://www.w3.org/TR/mediacapture-streams/#def-constraint-facingMode"><code>VideoFacingModeEnum</code></a></dfn> enumeration is defined in [<cite><a class="bibref" href="#bib-MEDIACAPTURE-STREAMS">MEDIACAPTURE-STREAMS</a></cite>].
@@ -401,7 +401,7 @@
     </p>
     <p>
       In this specification, the term <dfn data-dfn-type="dfn" id="dfn-capture-control-type">capture control type</dfn> refers to a specialized type of a file picker control that is optimized, for the user, for directly capturing media of a MIME type specified by the
-      <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#attr-input-accept"><code>accept</code></a> attribute, using a <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media capture mechanism</a> in its
+      <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#element-attrdef-input-accept"><code>accept</code></a> attribute, using a <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media capture mechanism</a> in its
       <a href="#dfn-preferred-facing-mode" class="internalDFN" data-link-type="dfn">preferred facing mode</a>.
     </p>
     <p>
@@ -442,8 +442,8 @@
       </span>
     </h2>
     <p>
-      When an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#the-input-element"><code>input</code></a> element's <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#attr-input-type"><code>type</code></a> attribute is in the <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#file-upload-state-(type=file)">File
-        Upload</a> state, and its <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#attr-input-accept"><code>accept</code></a> attribute is specified, the rules in this section apply.
+      When an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#the-input-element"><code>input</code></a> element's <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#element-attrdef-input-type"><code>type</code></a> attribute is in the <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#file-upload-state-typefile">File
+        Upload</a> state, and its <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#element-attrdef-input-accept"><code>accept</code></a> attribute is specified, the rules in this section apply.
     </p>
     <div>
       <pre class="def idl"><span class="idlEnum" id="idl-def-capturefacingmode" data-idl="" data-title="CaptureFacingMode">enum <span class="idlEnumID"><a data-lt="CaptureFacingMode" href="#dom-capturefacingmode" class="internalDFN" data-link-type="dfn" data-for=""><code>CaptureFacingMode</code></a></span> {
@@ -451,7 +451,7 @@
     <a href="#dom-capturefacingmode-environment" class="idlEnumItem">"environment"</a>
 };</span>
 
-<span class="idlInterface" id="idl-def-htmlinputelement-partial-1" data-idl="" data-title="HTMLInputElement">partial interface <span class="idlInterfaceID"><a data-lt="HTMLInputElement" data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#htmlinputelement" data-for=""><code>HTMLInputElement</code></a></span> {
+<span class="idlInterface" id="idl-def-htmlinputelement-partial-1" data-idl="" data-title="HTMLInputElement">partial interface <span class="idlInterfaceID"><a data-lt="HTMLInputElement" data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#htmlinputelement-htmlinputelement" data-for=""><code>HTMLInputElement</code></a></span> {
 <span class="idlAttribute" id="idl-def-htmlinputelement-capture" data-idl="" data-title="capture" data-dfn-for="htmlinputelement">    [<span class="extAttr"><span class="extAttrName"><a href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a></span></span>]
     attribute <span class="idlAttrType"><a href="#dom-capturefacingmode" class="internalDFN" data-link-type="dfn"><code>CaptureFacingMode</code></a></span> <span class="idlAttrName"><a data-lt="capture" href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn" data-for="HTMLInputElement"><code>capture</code></a></span>;</span>
 };</span></pre>
@@ -468,7 +468,7 @@
         </p>
       </div>
       <p>
-        The <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute is an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#enumerated-attribute">enumerated attribute</a> that specifies the <a href="#dfn-preferred-facing-mode" class="internalDFN" data-link-type="dfn">preferred facing mode</a> for the <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media capture
+        The <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute is an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#enumerated-attributes">enumerated attribute</a> that specifies the <a href="#dfn-preferred-facing-mode" class="internalDFN" data-link-type="dfn">preferred facing mode</a> for the <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media capture
           mechanism</a>. The attribute's keywords are <dfn data-dfn-for="capturefacingmode" data-dfn-type="dfn" id="dom-capturefacingmode-user" data-idl="" data-title="user"><code>user</code></dfn> and <dfn data-dfn-for="capturefacingmode" data-dfn-type="dfn" id="dom-capturefacingmode-environment" data-idl="" data-title="environment"><code>environment</code></dfn>, which map to the respective states <var>user</var> and <var>environment</var>. In addition, there is a third state, the <var>implementation-specific</var> state. The
         <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#missing-value-default">missing value default</a> is the
         <var>implementation-specific</var> state. The <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#invalid-value-default">invalid value
@@ -481,7 +481,7 @@
         </p>
       </div>
       <p>
-        The <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> IDL attribute <em class="rfc2119" title="MUST">MUST</em> <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#reflect">reflect</a> the respective content attribute of the same name.
+        The <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> IDL attribute <em class="rfc2119" title="MUST">MUST</em> <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#reflection">reflect</a> the respective content attribute of the same name.
       </p>
       <p>
         When the <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute is specified, the <a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">user agent</a>
@@ -499,7 +499,7 @@
         </div>
       </div>
       <p>
-        If the <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#attr-input-accept"><code>accept</code></a> attribute's value is set to a MIME type that has no associated <a href="#dfn-capture-control-type" class="internalDFN" data-link-type="dfn">capture control type</a>, the <a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">user agent</a> <em class="rfc2119" title="MUST">MUST</em> act as if there was no <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute.
+        If the <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#element-attrdef-input-accept"><code>accept</code></a> attribute's value is set to a MIME type that has no associated <a href="#dfn-capture-control-type" class="internalDFN" data-link-type="dfn">capture control type</a>, the <a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">user agent</a> <em class="rfc2119" title="MUST">MUST</em> act as if there was no <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute.
       </p>
     </div>
   </section>
@@ -611,7 +611,7 @@ input.onchange = <span class="hljs-function"><span class="hljs-keyword">function
       </li>
     </ul>
     <p data-link-for="HTMLInputElement">
-      When an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#the-input-element"><code>input</code></a> element's <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#attr-input-accept"><code>accept</code></a> attribute is set to
+      When an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#the-input-element"><code>input</code></a> element's <a data-link-type="dfn" href="https://www.w3.org/TR/html51/single-page.html#element-attrdef-input-accept"><code>accept</code></a> attribute is set to
       <code>image/*</code> and the <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute is specified as in the <a href="#example-1">Example 1</a> or <a href="#example-4">Example 4</a>, the file picker may render as presented on the right side. When the attribute is not specified, the file picker may render as represented on the left side.
     </p>
     <p>

--- a/releases/CR3.src.html
+++ b/releases/CR3.src.html
@@ -111,16 +111,16 @@
       <p>
         The <dfn data-cite="!HTML51#the-input-element"><code>input</code></dfn>
         element, its <dfn data-cite=
-        "!HTML51#attr-input-type"><code>type</code></dfn> attribute,
+        "!HTML51#element-attrdef-input-type"><code>type</code></dfn> attribute,
         <dfn data-cite=
-        "!HTML51#htmlinputelement"><code>HTMLInputElement</code></dfn> interface,
-        <dfn data-cite="!HTML51#attr-input-accept"><code>accept</code></dfn>
-        attribute, <dfn data-cite="!HTML51#file-upload-state-(type=file)">File
+        "!HTML51#htmlinputelement-htmlinputelement"><code>HTMLInputElement</code></dfn> interface,
+        <dfn data-cite="!HTML51#element-attrdef-input-accept"><code>accept</code></dfn>
+        attribute, <dfn data-cite="!HTML51#file-upload-state-typefile">File
         Upload</dfn> state, <dfn data-cite=
-        "!HTML51#enumerated-attribute">enumerated attribute</dfn>,
+        "!HTML51#enumerated-attributes">enumerated attribute</dfn>,
         <dfn data-cite="!HTML51#missing-value-default">missing value
         default</dfn>, <dfn data-cite="!HTML51#invalid-value-default">invalid
-        value default</dfn>, and <dfn data-cite="!HTML51#reflect">reflect</dfn>
+        value default</dfn>, and <dfn data-cite="!HTML51#reflection">reflect</dfn>
         are defined in [[!HTML51]].
       </p>
       <p>


### PR DESCRIPTION
Learning: fragment identifiers are not stable between HTML LS and HTML 5.1.