### PR TITLE
Fix references

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,19 +114,19 @@
         Terminology
       </h2>
       <p>
-        The <dfn data-cite="!HTML#the-input-element"><code>input</code></dfn>
+        The <dfn data-cite="!HTML51/sec-forms.html#the-input-element"><code>input</code></dfn>
         element, its <dfn data-cite=
-        "!HTML#attr-input-type"><code>type</code></dfn> attribute,
+        "!HTML51/sec-forms.html#element-attrdef-input-type"><code>type</code></dfn> attribute,
         <dfn data-cite=
-        "!HTML#htmlinputelement"><code>HTMLInputElement</code></dfn> interface,
-        <dfn data-cite="!HTML#attr-input-accept"><code>accept</code></dfn>
-        attribute, <dfn data-cite="!HTML#file-upload-state-(type=file)">File
+        "!HTML51/sec-forms.html#htmlinputelement-htmlinputelement"><code>HTMLInputElement</code></dfn> interface,
+        <dfn data-cite="!HTML51/sec-forms.html#element-attrdef-input-accept"><code>accept</code></dfn>
+        attribute, <dfn data-cite="!HTML51/sec-forms.html#element-statedef-input-file-upload">File
         Upload</dfn> state, <dfn data-cite=
-        "!HTML#enumerated-attribute">enumerated attribute</dfn>,
-        <dfn data-cite="!HTML#missing-value-default">missing value
-        default</dfn>, <dfn data-cite="!HTML#invalid-value-default">invalid
-        value default</dfn>, and <dfn data-cite="!HTML#reflect">reflect</dfn>
-        are defined in [[!HTML]].
+        "!HTML51/infrastructure.html#enumerated-attributes">enumerated attribute</dfn>,
+        <dfn data-cite="!HTML51/infrastructure.html#missing-value-default">missing value
+        default</dfn>, <dfn data-cite="!HTML51/infrastructure.html#invalid-value-default">invalid
+        value default</dfn>, and <dfn data-cite="!HTML51/infrastructure.html#reflection">reflect</dfn>
+        are defined in [[!HTML51]].
       </p>
       <p>
         The <dfn data-cite=
@@ -177,7 +177,7 @@
       </ul>
       <p>
         This specification builds upon the security and privacy protections
-        provided by the <code>&lt;input type="file"&gt;</code> [[HTML]] and the
+        provided by the <code>&lt;input type="file"&gt;</code> [[HTML51]] and the
         [[FILE-API]] specifications; in particular, it is expected that any
         offer to start capturing content from the user’s device would require a
         specific user interaction on an HTML element that is entirely

--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
         value default</dfn>, and <dfn data-cite="!HTML51/infrastructure.html#reflection">reflect</dfn>
         are defined in [[!HTML51]].
       </p>
+      <p>The <dfn cite="!custom-elements#cereactions"><code>[CEReactions]</code></dfn> WebIDL extended attribute is defined in [[!custom-elements]].</p>
       <p>
         The <dfn data-cite=
         "!MEDIACAPTURE-STREAMS#def-constraint-facingMode"><code>VideoFacingModeEnum</code></dfn>

--- a/releases/CR4.html
+++ b/releases/CR4.html
@@ -1081,7 +1081,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         default</a></dfn>, <dfn data-dfn-type="dfn" id="dfn-invalid-value-default"><a href="https://www.w3.org/TR/html51/infrastructure.html#invalid-value-default">invalid
         value default</a></dfn>, and <dfn data-dfn-type="dfn" id="dfn-reflect"><a href="https://www.w3.org/TR/html51/infrastructure.html#reflection">reflect</a></dfn> are defined in [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>].
         </p>
-        <p>The <dfn cite="!custom-elements#cereactions" data-dfn-type="dfn" id="dfn-x[cereactions]"><code>[CEReactions]</code></dfn> WebIDL extended attribute is defined in [<cite><a class="bibref" href="#bib-custom-elements">custom-elements</a></cite>].</p>
+        <p>The <dfn data-dfn-type="dfn" id="dfn-x[cereactions]"><a href="https://www.w3.org/TR/custom-elements/#cereactions"><code>[CEReactions]</code></a></dfn> WebIDL extended attribute is defined in [<cite><a class="bibref" href="#bib-custom-elements">custom-elements</a></cite>].</p>
         <p>
             The <dfn data-dfn-type="dfn" id="dfn-videofacingmodeenum"><a href="https://www.w3.org/TR/mediacapture-streams/#def-constraint-facingMode"><code>VideoFacingModeEnum</code></a></dfn> enumeration is defined in [<cite><a class="bibref" href="#bib-MEDIACAPTURE-STREAMS">MEDIACAPTURE-STREAMS</a></cite>].
         </p>
@@ -1136,7 +1136,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         </p>
         <div>
             <pre class="def idl"><span class="idlInterface" id="idl-def-htmlinputelement-partial-1" data-idl="" data-title="HTMLInputElement">partial interface <span class="idlInterfaceID"><a data-lt="HTMLInputElement" data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#htmlinputelement-htmlinputelement" data-for=""><code>HTMLInputElement</code></a></span> {
-<span class="idlAttribute" id="idl-def-htmlinputelement-capture" data-idl="" data-title="capture" data-dfn-for="htmlinputelement">    [<span class="extAttr"><span class="extAttrName"><a href="https://html.spec.whatwg.org/multipage/#cereactions">CEReactions</a></span></span>]
+<span class="idlAttribute" id="idl-def-htmlinputelement-capture" data-idl="" data-title="capture" data-dfn-for="htmlinputelement">    [<span class="extAttr"><span class="extAttrName"><a href="https://www.w3.org/TR/custom-elements/#cereactions">CEReactions</a></span></span>]
     attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlAttrName"><a data-lt="capture" href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn" data-for="HTMLInputElement"><code>capture</code></a></span>;</span>
 };</span></pre>
         </div>

--- a/releases/CR4.html
+++ b/releases/CR4.html
@@ -836,7 +836,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
     </style>
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-CR">
     <link rel="canonical" href="https://www.w3.org/TR/html-media-capture/">
-    <meta name="generator" content="ReSpec 16.0.0">
+    <meta name="generator" content="ReSpec 16.2.0">
     <script id="initialUserConfig" type="application/json">
         {
             "specStatus": "CR",
@@ -1041,7 +1041,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <p><em>This section is non-normative.</em></p>
         <p data-link-for="HTMLInputElement">
             The <cite>HTML Media Capture</cite> specification extends the
-            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#htmlinputelement"><code>HTMLInputElement</code></a> interface with a <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a>            attribute. The
+            <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#htmlinputelement-htmlinputelement"><code>HTMLInputElement</code></a> interface with a <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a>            attribute. The
             <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute allows authors to declaratively request use of a <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media capture mechanism</a>,
             such as a camera or microphone, from within a file upload control, for capturing media on the spot.
         </p>
@@ -1073,14 +1073,15 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <h2 id="x3.-terminology"><span class="secno">3. </span> Terminology
         </h2>
         <p>
-            The <dfn data-dfn-type="dfn" id="dfn-input"><a href="https://html.spec.whatwg.org/multipage/#the-input-element"><code>input</code></a></dfn> element, its <dfn data-dfn-type="dfn" id="dfn-type"><a href="https://html.spec.whatwg.org/multipage/#attr-input-type"><code>type</code></a></dfn>            attribute,
-            <dfn data-dfn-for="" data-dfn-type="dfn" id="dom-htmlinputelement" data-idl="" data-title="HTMLInputElement"><a href="https://html.spec.whatwg.org/multipage/#htmlinputelement"><code>HTMLInputElement</code></a></dfn> interface,
-            <dfn data-dfn-type="dfn" id="dfn-accept"><a href="https://html.spec.whatwg.org/multipage/#attr-input-accept"><code>accept</code></a></dfn> attribute, <dfn data-dfn-type="dfn" id="dfn-file-upload"><a href="https://html.spec.whatwg.org/multipage/#file-upload-state-(type=file)">File
-        Upload</a></dfn> state, <dfn data-dfn-type="dfn" id="dfn-enumerated-attribute"><a href="https://html.spec.whatwg.org/multipage/#enumerated-attribute">enumerated attribute</a></dfn>,
-            <dfn data-dfn-type="dfn" id="dfn-missing-value-default"><a href="https://html.spec.whatwg.org/multipage/#missing-value-default">missing value
-        default</a></dfn>, <dfn data-dfn-type="dfn" id="dfn-invalid-value-default"><a href="https://html.spec.whatwg.org/multipage/#invalid-value-default">invalid
-        value default</a></dfn>, and <dfn data-dfn-type="dfn" id="dfn-reflect"><a href="https://html.spec.whatwg.org/multipage/#reflect">reflect</a></dfn> are defined in [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>].
+            The <dfn data-dfn-type="dfn" id="dfn-input"><a href="https://www.w3.org/TR/html51/sec-forms.html#the-input-element"><code>input</code></a></dfn> element, its <dfn data-dfn-type="dfn" id="dfn-type"><a href="https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-input-type"><code>type</code></a></dfn>            attribute,
+            <dfn data-dfn-for="" data-dfn-type="dfn" id="dom-htmlinputelement" data-idl="" data-title="HTMLInputElement"><a href="https://www.w3.org/TR/html51/sec-forms.html#htmlinputelement-htmlinputelement"><code>HTMLInputElement</code></a></dfn> interface,
+            <dfn data-dfn-type="dfn" id="dfn-accept"><a href="https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-input-accept"><code>accept</code></a></dfn> attribute, <dfn data-dfn-type="dfn" id="dfn-file-upload"><a href="https://www.w3.org/TR/html51/sec-forms.html#element-statedef-input-file-upload">File
+        Upload</a></dfn> state, <dfn data-dfn-type="dfn" id="dfn-enumerated-attribute"><a href="https://www.w3.org/TR/html51/infrastructure.html#enumerated-attributes">enumerated attribute</a></dfn>,
+            <dfn data-dfn-type="dfn" id="dfn-missing-value-default"><a href="https://www.w3.org/TR/html51/infrastructure.html#missing-value-default">missing value
+        default</a></dfn>, <dfn data-dfn-type="dfn" id="dfn-invalid-value-default"><a href="https://www.w3.org/TR/html51/infrastructure.html#invalid-value-default">invalid
+        value default</a></dfn>, and <dfn data-dfn-type="dfn" id="dfn-reflect"><a href="https://www.w3.org/TR/html51/infrastructure.html#reflection">reflect</a></dfn> are defined in [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>].
         </p>
+        <p>The <dfn cite="!custom-elements#cereactions" data-dfn-type="dfn" id="dfn-x[cereactions]"><code>[CEReactions]</code></dfn> WebIDL extended attribute is defined in [<cite><a class="bibref" href="#bib-custom-elements">custom-elements</a></cite>].</p>
         <p>
             The <dfn data-dfn-type="dfn" id="dfn-videofacingmodeenum"><a href="https://www.w3.org/TR/mediacapture-streams/#def-constraint-facingMode"><code>VideoFacingModeEnum</code></a></dfn> enumeration is defined in [<cite><a class="bibref" href="#bib-MEDIACAPTURE-STREAMS">MEDIACAPTURE-STREAMS</a></cite>].
         </p>
@@ -1090,7 +1091,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <p>
             In this specification, the term <dfn data-dfn-type="dfn" id="dfn-capture-control-type">capture control type</dfn> refers to a specialized type of a file picker control that is optimized, for the user, for directly capturing media of a MIME
             type specified by the
-            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#attr-input-accept"><code>accept</code></a> attribute, using a <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media capture mechanism</a>            in its
+            <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-input-accept"><code>accept</code></a> attribute, using a <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media capture mechanism</a>            in its
             <a href="#dfn-preferred-facing-mode" class="internalDFN" data-link-type="dfn">preferred facing mode</a>.
         </p>
         <p>
@@ -1117,8 +1118,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
             </li>
         </ul>
         <p>
-            This specification builds upon the security and privacy protections provided by the <code>&lt;input type="file"&gt;</code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] and the [<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>]
-            specifications; in particular, it is expected that any offer to start capturing content from the user’s device would require a specific user interaction on an HTML element that is entirely controlled by the user agent.
+            This specification builds upon the security and privacy protections provided by the <code>&lt;input type="file"&gt;</code> [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] and the [
+            <cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] specifications; in particular, it is expected that any offer to start capturing content from the user’s device would require a specific user interaction on an HTML element that
+            is entirely controlled by the user agent.
         </p>
         <p>
             Implementors should take care to prevent additional leakage of privacy-sensitive data from captured media. For instance, embedding the user’s location in the metadata of captured media (e.g. EXIF) might transmit more private data than the user is expecting.
@@ -1129,18 +1131,18 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         <h2 id="x5.-the-capture-attribute"><span class="secno">5. </span> The <dfn data-dfn-for="htmlinputelement" data-dfn-type="dfn" id="dom-htmlinputelement-capture" data-idl="" data-title="capture"><code>capture</code></dfn> attribute
         </h2>
         <p>
-            When an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#the-input-element"><code>input</code></a> element's <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#attr-input-type"><code>type</code></a>            attribute is in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#file-upload-state-(type=file)">File
-        Upload</a> state, and its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#attr-input-accept"><code>accept</code></a> attribute is specified, the rules in this section apply.
+            When an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#the-input-element"><code>input</code></a> element's <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-input-type"><code>type</code></a>            attribute is in the <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#element-statedef-input-file-upload">File
+        Upload</a> state, and its <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-input-accept"><code>accept</code></a> attribute is specified, the rules in this section apply.
         </p>
         <div>
-            <pre class="def idl"><span class="idlInterface" id="idl-def-htmlinputelement-partial-1" data-idl="" data-title="HTMLInputElement">partial interface <span class="idlInterfaceID"><a data-lt="HTMLInputElement" data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#htmlinputelement" data-for=""><code>HTMLInputElement</code></a></span> {
+            <pre class="def idl"><span class="idlInterface" id="idl-def-htmlinputelement-partial-1" data-idl="" data-title="HTMLInputElement">partial interface <span class="idlInterfaceID"><a data-lt="HTMLInputElement" data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#htmlinputelement-htmlinputelement" data-for=""><code>HTMLInputElement</code></a></span> {
 <span class="idlAttribute" id="idl-def-htmlinputelement-capture" data-idl="" data-title="capture" data-dfn-for="htmlinputelement">    [<span class="extAttr"><span class="extAttrName"><a href="https://html.spec.whatwg.org/multipage/#cereactions">CEReactions</a></span></span>]
     attribute <span class="idlAttrType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span> <span class="idlAttrName"><a data-lt="capture" href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn" data-for="HTMLInputElement"><code>capture</code></a></span>;</span>
 };</span></pre>
         </div>
         <div>
             <p>
-                The <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#enumerated-attribute">enumerated attribute</a>                whose state specifies the <a href="#dfn-preferred-facing-mode" class="internalDFN" data-link-type="dfn">preferred facing mode</a> for the <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media
+                The <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute is an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/infrastructure.html#enumerated-attributes">enumerated attribute</a>                whose state specifies the <a href="#dfn-preferred-facing-mode" class="internalDFN" data-link-type="dfn">preferred facing mode</a> for the <a href="#dfn-media-capture-mechanism" class="internalDFN" data-link-type="dfn">media
           capture mechanism</a>.
             </p>
             <p>
@@ -1154,8 +1156,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 <var>implementation-specific</var> state.
             </p>
             <p>
-                The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#missing-value-default">missing value default</a> is the
-                <var>implementation-specific</var> state. The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#invalid-value-default">invalid value
+                The <a data-link-type="dfn" href="https://www.w3.org/TR/html51/infrastructure.html#missing-value-default">missing value default</a> is the
+                <var>implementation-specific</var> state. The <a data-link-type="dfn" href="https://www.w3.org/TR/html51/infrastructure.html#invalid-value-default">invalid value
           default</a> is also the <var>implementation-specific</var> state.
             </p>
             <div class="note">
@@ -1166,7 +1168,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 </p>
             </div>
             <p>
-                The <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> IDL attribute <em class="rfc2119" title="MUST">MUST</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#reflect">reflect</a>                the respective content attribute of the same name.
+                The <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> IDL attribute <em class="rfc2119" title="MUST">MUST</em> <a data-link-type="dfn" href="https://www.w3.org/TR/html51/infrastructure.html#reflection">reflect</a>                the respective content attribute of the same name.
             </p>
             <p>
                 When the <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute is specified, the <a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">user agent</a>
@@ -1185,7 +1187,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                 </div>
             </div>
             <p>
-                If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#attr-input-accept"><code>accept</code></a> attribute's value is set to a MIME type that has no associated <a href="#dfn-capture-control-type" class="internalDFN"
+                If the <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-input-accept"><code>accept</code></a> attribute's value is set to a MIME type that has no associated <a href="#dfn-capture-control-type" class="internalDFN"
                     data-link-type="dfn">capture control type</a>, the <a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">user agent</a> <em class="rfc2119" title="MUST">MUST</em> act as if there was no <a href="#dom-htmlinputelement-capture"
                     class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute.
             </p>
@@ -1299,7 +1301,7 @@ input.onchange = <span class="hljs-function"><span class="hljs-keyword">function
             </li>
         </ul>
         <p data-link-for="HTMLInputElement">
-            When an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#the-input-element"><code>input</code></a> element's <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/#attr-input-accept"><code>accept</code></a>            attribute is set to
+            When an <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#the-input-element"><code>input</code></a> element's <a data-link-type="dfn" href="https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-input-accept"><code>accept</code></a>            attribute is set to
             <code>image/*</code> and the <a href="#dom-htmlinputelement-capture" class="internalDFN" data-link-type="dfn"><code>capture</code></a> attribute is specified as in the <a href="#example-1">Example 1</a> or <a href="#example-4">Example 4</a>,
             the file picker may render as presented on the right side. When the attribute is not specified, the file picker may render as represented on the left side.
         </p>
@@ -1316,8 +1318,6 @@ input.onchange = <span class="hljs-function"><span class="hljs-keyword">function
             <h3 id="b.1-normative-references"><span class="secno">B.1 </span>Normative references</h3>
             <dl class="bibliography"><dt id="bib-FILE-API">[FILE-API]</dt>
                 <dd><a href="https://www.w3.org/TR/FileAPI/"><cite>File API</cite></a>. Arun Ranganathan; Jonas Sicking. W3C. 21 April 2015. W3C Working Draft. URL: <a href="https://www.w3.org/TR/FileAPI/">https://www.w3.org/TR/FileAPI/</a>
-                </dd><dt id="bib-HTML">[HTML]</dt>
-                <dd><a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters. WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
                 </dd><dt id="bib-HTML51">[HTML51]</dt>
                 <dd><a href="https://www.w3.org/TR/html51/"><cite>HTML 5.1 2nd Edition</cite></a>. Steve Faulkner; Arron Eicholz; Travis Leithead; Alex Danilo. W3C. 3 August 2017. W3C Proposed Recommendation. URL: <a href="https://www.w3.org/TR/html51/">https://www.w3.org/TR/html51/</a>
                 </dd><dt id="bib-MEDIACAPTURE-STREAMS">[MEDIACAPTURE-STREAMS]</dt>
@@ -1328,12 +1328,16 @@ input.onchange = <span class="hljs-function"><span class="hljs-keyword">function
                 <dd><a href="https://tools.ietf.org/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner. IETF. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
                 </dd><dt id="bib-WEBIDL-1">[WEBIDL-1]</dt>
                 <dd><a href="https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/"><cite>WebIDL Level 1</cite></a>. Cameron McCormack. W3C. 15 December 2016. W3C Recommendation. URL: <a href="https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/">https://www.w3.org/TR/2016/REC-WebIDL-1-20161215/</a>
+                </dd><dt id="bib-custom-elements">[custom-elements]</dt>
+                <dd><a href="https://www.w3.org/TR/custom-elements/"><cite>Custom Elements</cite></a>. Domenic Denicola. W3C. 13 October 2016. W3C Working Draft. URL: <a href="https://www.w3.org/TR/custom-elements/">https://www.w3.org/TR/custom-elements/</a>
                 </dd>
             </dl>
         </section>
         <section id="informative-references">
             <h3 id="b.2-informative-references"><span class="secno">B.2 </span>Informative references</h3>
-            <dl class="bibliography"><dt id="bib-WEBIDL">[WEBIDL]</dt>
+            <dl class="bibliography"><dt id="bib-HTML">[HTML]</dt>
+                <dd><a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters. WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+                </dd><dt id="bib-WEBIDL">[WEBIDL]</dt>
                 <dd><a href="https://heycam.github.io/webidl/"><cite>Web IDL</cite></a>. Cameron McCormack; Boris Zbarsky; Tobie Langel. W3C. 15 December 2016. W3C Editor's Draft. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
                 </dd>
             </dl>

--- a/releases/CR4.src.html
+++ b/releases/CR4.src.html
@@ -122,20 +122,21 @@
         Terminology
       </h2>
       <p>
-        The <dfn data-cite="!HTML#the-input-element"><code>input</code></dfn>
+        The <dfn data-cite="!HTML51/sec-forms.html#the-input-element"><code>input</code></dfn>
         element, its <dfn data-cite=
-        "!HTML#attr-input-type"><code>type</code></dfn> attribute,
+        "!HTML51/sec-forms.html#element-attrdef-input-type"><code>type</code></dfn> attribute,
         <dfn data-cite=
-        "!HTML#htmlinputelement"><code>HTMLInputElement</code></dfn> interface,
-        <dfn data-cite="!HTML#attr-input-accept"><code>accept</code></dfn>
-        attribute, <dfn data-cite="!HTML#file-upload-state-(type=file)">File
+        "!HTML51/sec-forms.html#htmlinputelement-htmlinputelement"><code>HTMLInputElement</code></dfn> interface,
+        <dfn data-cite="!HTML51/sec-forms.html#element-attrdef-input-accept"><code>accept</code></dfn>
+        attribute, <dfn data-cite="!HTML51/sec-forms.html#element-statedef-input-file-upload">File
         Upload</dfn> state, <dfn data-cite=
-        "!HTML#enumerated-attribute">enumerated attribute</dfn>,
-        <dfn data-cite="!HTML#missing-value-default">missing value
-        default</dfn>, <dfn data-cite="!HTML#invalid-value-default">invalid
-        value default</dfn>, and <dfn data-cite="!HTML#reflect">reflect</dfn>
+        "!HTML51/infrastructure.html#enumerated-attributes">enumerated attribute</dfn>,
+        <dfn data-cite="!HTML51/infrastructure.html#missing-value-default">missing value
+        default</dfn>, <dfn data-cite="!HTML51/infrastructure.html#invalid-value-default">invalid
+        value default</dfn>, and <dfn data-cite="!HTML51/infrastructure.html#reflection">reflect</dfn>
         are defined in [[!HTML51]].
       </p>
+      <p>The <dfn cite="!custom-elements#cereactions"><code>[CEReactions]</code></dfn> WebIDL extended attribute is defined in [[!custom-elements]].</p>
       <p>
         The <dfn data-cite=
         "!MEDIACAPTURE-STREAMS#def-constraint-facingMode"><code>VideoFacingModeEnum</code></dfn>
@@ -185,8 +186,8 @@
       </ul>
       <p>
         This specification builds upon the security and privacy protections
-        provided by the <code>&lt;input type="file"&gt;</code> [[HTML51]] and
-        the [[FILE-API]] specifications; in particular, it is expected that any
+        provided by the <code>&lt;input type="file"&gt;</code> [[HTML51]] and the
+        [[FILE-API]] specifications; in particular, it is expected that any
         offer to start capturing content from the user’s device would require a
         specific user interaction on an HTML element that is entirely
         controlled by the user agent.

--- a/releases/CR4.src.html
+++ b/releases/CR4.src.html
@@ -136,7 +136,7 @@
         value default</dfn>, and <dfn data-cite="!HTML51/infrastructure.html#reflection">reflect</dfn>
         are defined in [[!HTML51]].
       </p>
-      <p>The <dfn cite="!custom-elements#cereactions"><code>[CEReactions]</code></dfn> WebIDL extended attribute is defined in [[!custom-elements]].</p>
+      <p>The <dfn data-cite="!custom-elements#cereactions"><code>[CEReactions]</code></dfn> WebIDL extended attribute is defined in [[!custom-elements]].</p>
       <p>
         The <dfn data-cite=
         "!MEDIACAPTURE-STREAMS#def-constraint-facingMode"><code>VideoFacingModeEnum</code></dfn>


### PR DESCRIPTION
- Fix references to use HTML51
- Add normative reference to Custom Element for CEReactions

PTAL @dontcallmedom and thanks for fixing the respec bug and for the spec updates.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/html-media-capture/cr4-references.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/html-media-capture/62e146b...7c89bae.html)