### PR TITLE
Overflow images for a better narrow layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@ uploading it e.g. for client-side image editing purposes, using the <code>
         "#example-4">Example 4</a>, the file picker can be rendered as
         presented below:
       </p>
-      <p>
+      <p style="overflow: visible;">
         <img alt=
         "A File picker control in the Image Capture state."
         src="images/image-capture-state.png">
@@ -385,7 +385,7 @@ uploading it e.g. for client-side image editing purposes, using the <code>
         When the attribute is not specified, the file picker can be rendered
         as represented below:
       </p>
-      <p>
+      <p style="overflow: visible;">
         <img alt=
         "A File picker control in the File Upload state."
         src="images/file-upload-state.png">


### PR DESCRIPTION
CSS is hard.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/html-media-capture/image-editorial.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/html-media-capture/2817c5f...a36a0dc.html)