### PR TITLE
Make ED reflect TR

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
               {name: "Ilkka Oksanen", company: "Nokia (until May 10, 2012)"},
               {name: "Dominique Hazaël-Massieux", company: "W3C (until May 10, 2012)"}
           ],
-          publishDate:          "2018-01-30",
+          publishDate:          "2018-02-01",
           previousPublishDate:  "2017-11-28",
           previousMaturity:     "PR",
           edDraftURI:           "https://w3c.github.io/html-media-capture/",

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <script class='remove'>
       var respecConfig = {
           specStatus:           "REC",
+          errata:               "https://github.com/w3c/html-media-capture/labels/errata",
           shortName:            "html-media-capture",
           editors: [
               {name: "Anssi Kostiainen", company: "Intel"},

--- a/index.html
+++ b/index.html
@@ -10,18 +10,19 @@
     </script>
     <script class='remove'>
       var respecConfig = {
-          specStatus:           "ED",
+          specStatus:           "REC",
           shortName:            "html-media-capture",
           editors: [
               {name: "Anssi Kostiainen", company: "Intel"},
               {name: "Ilkka Oksanen", company: "Nokia (until May 10, 2012)"},
               {name: "Dominique Hazaël-Massieux", company: "W3C (until May 10, 2012)"}
           ],
-          // publishDate:          "2017-04-20",
-          previousPublishDate:  "2014-09-09",
-          previousMaturity:     "CR",
+          publishDate:          "2018-01-30",
+          previousPublishDate:  "2017-11-28",
+          previousMaturity:     "PR",
           edDraftURI:           "https://w3c.github.io/html-media-capture/",
           crEnd:                "2017-06-20",
+          prEnd:                "2017-12-26",
           wg:           "Device and Sensors Working Group",
           wgURI:        "https://www.w3.org/2009/dap/",
           wgPublicList: "public-device-apis",
@@ -64,14 +65,11 @@
     </section>
     <section id="sotd">
       <p>
-        Since <a href=
-        "https://www.w3.org/TR/2017/CR-html-media-capture-20170504/">Candidate
-        Recommendation 04 May 2017</a>, the <a data-link-for=
-        "HTMLInputElement">capture</a> IDL attribute was changed from an
-        enumeration into a <code>DOMString</code>. This change aligns this
-        specification with the HTML specification changes that <a href=
-        "https://github.com/whatwg/html/pull/2585">removed the IDL enumeration
-        reflection</a>.
+        An HTML Media Capture <a href="https://www.w3.org/TR/2017/PR-html-media-capture-20171128/">Proposed Recommendation</a> was published on 28 November 2017, no further normative changes have been made since then.
+
+        Errata for this document are recorded as issues.
+
+        The <a href="https://www.w3.org/2009/dap/wiki/ImplementationStatus">implementation report</a> produced for this version demonstrates there are two independent interoperable implementations.
       </p>
     </section>
     <section class="informative">


### PR DESCRIPTION
@xfq @dontcallmedom, is there a best practice to make the ED URL reflect TR when a spec reaches Rec?

If so, feel free to merge this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-media-capture/pull/22.html" title="Last updated on Feb 1, 2018, 9:25 AM GMT (20dcc37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-media-capture/22/2503591...20dcc37.html" title="Last updated on Feb 1, 2018, 9:25 AM GMT (20dcc37)">Diff</a>