### PR TITLE
Define the empty string as a conforming value

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,16 +227,13 @@
           capture mechanism</a>.
         </p>
         <p>
-          The attribute's keywords are <dfn><code>user</code></dfn> and
-          <dfn><code>environment</code></dfn>, which map to the respective
-          states <var>user</var> and <var>environment</var>. The semantics of
-          the states <var>user</var> and <var>environment</var> mirror the
+          The attribute's keywords are <dfn><code>user</code></dfn>,
+          <dfn><code>environment</code></dfn>, and the empty string, which map
+          to the <var>user</var>, <var>environment</var>, and the
+          <var>implementation-specific</var> state respectively. The semantics
+          of the states <var>user</var> and <var>environment</var> mirror the
           similarly named enumeration values defined in
           <a><code>VideoFacingModeEnum</code></a>.
-        </p>
-        <p>
-          In addition, there is a third state, the
-          <var>implementation-specific</var> state.
         </p>
         <p>
           The <a>missing value default</a> is the


### PR DESCRIPTION
Fix #34


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-media-capture/pull/35.html" title="Last updated on Mar 24, 2020, 5:24 PM UTC (fa5281b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-media-capture/35/a255e6e...fa5281b.html" title="Last updated on Mar 24, 2020, 5:24 PM UTC (fa5281b)">Diff</a>