### PR TITLE
Editorial: fix broken references

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,9 +105,9 @@
         Terminology
       </h2>
       <p>
-        <dfn data-cite="HTML/sec-forms.html#element-statedef-input-file-upload">File
+        <dfn data-cite="HTML/input.html#file-upload-state-(type=file)">File
         Upload</dfn> state, <dfn data-cite=
-        "HTML/infrastructure.html#enumerated-attributes">enumerated attribute</dfn>,
+        "HTML/common-microsyntaxes.html#enumerated-attribute">enumerated attribute</dfn>,
         <dfn data-cite="HTML/infrastructure.html#missing-value-default">missing value
         default</dfn>, <dfn data-cite="HTML/infrastructure.html#invalid-value-default">invalid
         value default</dfn>


### PR DESCRIPTION
Adapt to HTML spec changes.

Fix #40

@dontcallmedom maybe a future version of Strudy will submit a PR to fix the broken references it detects :-) This is a semi-serious suggestion, I looked at https://github.com/w3c/strudy/issues and I'm not sure if that'd be feasible or in scope for this tool.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-media-capture/pull/41.html" title="Last updated on Apr 12, 2023, 2:18 PM UTC (3235674)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-media-capture/41/82d1680...3235674.html" title="Last updated on Apr 12, 2023, 2:18 PM UTC (3235674)">Diff</a>